### PR TITLE
[TS-2037] Change import subcommand `game-id` flag to positional

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,7 +169,6 @@ pub enum Commands {
         /// The identifier of the game to import.
         ///
         /// Use the `list` command to query the list of imported and supported games.
-        #[clap(long, short)]
         game_id: String,
 
         /// The platform to import the game from. Leave blank to have tcli decide for you.


### PR DESCRIPTION
## TL;DR
This change brings the `import` subcommand in-line with other commands which require the user to pass a game id.