### PR TITLE
[TS-2040/] Fix panic and test failure caused by invalid TCLI_HOME index filesystem state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Build tests
-      run: cargo test --target ${{ matrix.target }} --no-run
+      run: cargo test --target ${{ matrix.target }} --no-run -- --test-threads=1
 
     - name: Run tests
-      run: cargo test --target ${{ matrix.target }} --no-fail-fast
+      run: cargo test --target ${{ matrix.target }} --no-fail-fast -- --test-threads=1

--- a/src/package/index.rs
+++ b/src/package/index.rs
@@ -154,6 +154,19 @@ impl PackageIndex {
         }
 
         let index_dir = tcli_home.join("index");
+
+        let lookup = index_dir.join("lookup.json");
+        let index = index_dir.join("index.json");
+        let header = index_dir.join("header.json");
+
+        if !index_dir.is_dir() {
+            fs::create_dir(&index_dir)?;
+        }
+
+        if !lookup.is_file() || !index.is_file() || !header.is_file() {
+            PackageIndex::sync(tcli_home).await?;
+        }
+
         let lookup: HashMap<PackageReference, LookupTableEntry> = {
             let contents = fs::read_to_string(index_dir.join("lookup.json"))?;
             serde_json::from_str(&contents)?


### PR DESCRIPTION
## TL;DR
This PR adds additional checks to the `PackageIndex::open` function to ensure that:
1. `TCLI_HOME/index` is created if it does not exist
2. The package index is synchronized if any of the following files are not present: `lookup.json`, `index.json`, `header.json`.

It also includes a simple fix to the test workflow to ensure that tests are being run sequentially. It's not a great solution, but it's an alright stopgap until I refactor how tests are setup.