### PR TITLE
Add JSON argument deserialization for calls from external tooling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,21 +1,24 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
 
 use crate::ts::package_reference::PackageReference;
 use crate::ts::version::Version;
 use crate::util::os::OS;
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Serialize, Deserialize, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     #[clap(subcommand)]
+    #[serde(flatten)]
     pub commands: Commands,
 }
 
 const DEFAULT_MANIFEST: &str = "./";
 
-#[derive(Subcommand, Debug, Clone)]
+#[derive(Subcommand, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InitSubcommand {
     /// Creates a tcli project which can be used to build and publish a package.
     Project {
@@ -35,7 +38,8 @@ pub enum InitSubcommand {
     Profile,
 }
 
-#[derive(Subcommand, Debug, Clone)]
+#[derive(Subcommand, Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ListSubcommand {
     /// List the platforms tcli supports.
     Platforms {
@@ -67,7 +71,7 @@ pub enum ListSubcommand {
     },
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Serialize, Deserialize, Debug)]
 pub enum ExternSubcommand {
     /// Get the path of a game with the specified label.
     GameData {
@@ -79,7 +83,8 @@ pub enum ExternSubcommand {
     },
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum Commands {
     /// Initialize a new project configuration.
     Init {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::io;
+use std::{env, io};
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -23,6 +23,7 @@ use crate::package::Package;
 use crate::project::lock::LockFile;
 use crate::project::overrides::ProjectOverrides;
 use crate::project::Project;
+use crate::ts::experimental;
 use crate::ui::reporter::IndicatifReporter;
 
 mod cli;
@@ -50,7 +51,19 @@ async fn main() -> Result<(), Error> {
         std::fs::create_dir_all(TCLI_HOME.as_path())?;
     }
 
-    let test: Result<(), Error> = match Args::parse().commands {
+    let args = env::args().collect::<Vec<_>>();
+    let args = args
+        .iter()
+        .position(|x| x == "--json")
+        .and_then(|x| {
+            let json = &args.get(x + 1)
+                .expect("Missing JSON argument.");
+            serde_json::from_str(json)
+                .expect("Recieved an invalid JSON object as an argument.")
+        })
+        .unwrap_or_else(Args::parse);
+
+    let test: Result<(), Error> = match args.commands {
         Commands::Init {
             command,
             overwrite,


### PR DESCRIPTION
This allows structured arguments to be passed from external tooling (mod managers, etc.) in a way that closely mirrors normal positional arguments. JSON mode is enabled by passing the `--json` argument.

For example, `tcli --json '{"add":{"packages":["JereKuusela-Expand_World-1.56.0"],"project_path":"./","sync":false}}'` mirrors the `tcli add JereKuusela-Expand_world-1.56.0` command.